### PR TITLE
Ci build

### DIFF
--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+yum -y install docker 
+service docker start
+
 cd grafana-hawkular
-Docker build -t registry.devshift.net/perf/osd-monitor:latest . 
+docker build -t registry.devshift.net/perf/osd-monitor:latest . 
 if [ $? -eq 0 ]; then
   docker push registry.devshift.net/perf/osd-monitor:latest
   rtn=$?

--- a/cico_deploy.sh
+++ b/cico_deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd grafana-hawkular
+Docker build -t registry.devshift.net/perf/osd-monitor:latest . 
+if [ $? -eq 0 ]; then
+  docker push registry.devshift.net/perf/osd-monitor:latest
+  rtn=$?
+fi
+exit $rtn


### PR DESCRIPTION
The cico script will do the needed work to get a build, and push it into a registry that the runtime OSD clusters can reach. We need to also setup the actual build job in jenkins ( I've got a PR ready ) and then set up the deployment for OSD ( @fche you should have the info needed to do that, otherwise let me know ) 