### PR TITLE
reformat to multiline & add network IO stats

### DIFF
--- a/pcp-central-logger/pmmgr-node/monitor-host-env
+++ b/pcp-central-logger/pmmgr-node/monitor-host-env
@@ -1,1 +1,14 @@
-/pmrep-zabbix.sh -t 60 mem.util.available mem.util.free mem.util.used kernel.cpu.util.user kernel.cpu.util.sys kernel.cpu.util.idle kernel.cpu.util.nice kernel.cpu.util.intr kernel.cpu.util.wait kernel.cpu.util.steal kernel.all.uptime
+/pmrep-zabbix.sh -t 60 \
+  mem.util.available \
+  mem.util.free \
+  mem.util.used \
+  kernel.cpu.util.user \
+  kernel.cpu.util.sys \
+  kernel.cpu.util.idle \
+  kernel.cpu.util.nice \
+  kernel.cpu.util.intr \
+  kernel.cpu.util.wait \
+  kernel.cpu.util.steal \
+  kernel.all.uptime \
+  network.interface.in.bytes \
+  network.interface.out.bytes


### PR DESCRIPTION
@fche split the commmand to multiple lines for readability and added network IO metrics. WDYT?