### PR TITLE
Enable build on RHEL

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -6,7 +6,7 @@ function build_push() {
     local TARGET_IMAGE=$1
     local IMAGE_TAG=$2
 
-    docker build -t ${TARGET_IMAGE}:latest .
+    docker build -t ${TARGET_IMAGE}:latest -f ${DOCKERFILE} .
     docker tag ${TARGET_IMAGE}:latest ${TARGET_IMAGE}:${IMAGE_TAG}
     docker push ${TARGET_IMAGE}:${IMAGE_TAG}
     docker push ${TARGET_IMAGE}:latest
@@ -17,11 +17,23 @@ service docker start
 
 [ -f jenkins-env ] && cat jenkins-env | grep -e GIT -e DEVSHIFT > inherit-env
 [ -f inherit-env ] && . inherit-env
+
+# TARGET variable gives ability to switch context for building rhel based images, default is "centos"
+# If CI slave is configured with TARGET="rhel" RHEL based images should be generated then.
+TARGET=${TARGET:-"centos"}
+
 TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-REGISTRY="push.registry.devshift.net"
+
+if [ "$TARGET" == "rhel" ]; then
+    DOCKERFILE="Dockerfile.rhel"
+    REGISTRY=${DOCKER_REGISTRY:-"registry.devshift.net/osio-prod"}
+else
+    DOCKERFILE="Dockerfile"
+    REGISTRY="push.registry.devshift.net"
+fi
 
 if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+    docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" "${REGISTRY}"
 else
     echo "Could not login, missing credentials for the registry"
 fi

--- a/mm-zabbix-relay/Dockerfile.rhel
+++ b/mm-zabbix-relay/Dockerfile.rhel
@@ -1,0 +1,18 @@
+FROM registry.devshift.net/osio-prod/base/pcp:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+
+ADD pmmgr-mm /etc/pcp/pmmgr-mm
+
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \  
+    /usr/bin/fix-permissions /var/log/pcp
+
+ENV MALLOC_ARENA_MAX 1
+ENV ZABBIX_SERVER localhost
+ENV ZABBIX_HOSTNAME localhost
+ENV PCP_METRICS "cgroup.memory.usage network.interface.in.bytes network.interface.out.bytes cgroup.cpuacct.usage"
+
+VOLUME /var/log/pcp
+ENTRYPOINT [ "/usr/libexec/pcp/bin/pmmgr", "-c", "/etc/pcp/pmmgr-mm", "-v" ]

--- a/oso-central-logger/Dockerfile.rhel
+++ b/oso-central-logger/Dockerfile.rhel
@@ -1,0 +1,24 @@
+FROM registry.devshift.net/osio-prod/base/osd-loggers:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+COPY pmmgr+pmcd.sh   /pmmgr+pmcd.sh
+
+COPY regen-tenant-list.sh /regen-tenant-list.sh
+
+ADD pmmgr-tenants /etc/pcp/pmmgr-tenants
+
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /regen-tenant-list.sh && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \
+    /usr/bin/fix-permissions /var/log/pcp
+
+ENV MALLOC_ARENA_MAX 1
+ENV ZABBIX_SERVER    localhost
+
+ENV VALGRIND ""
+
+# ENV VALGRIND /usr/bin/valgrind
+
+VOLUME /var/log/pcp
+ENTRYPOINT [ "/bin/sh", "/pmmgr+pmcd.sh" ]

--- a/oso-central-webapi-guard/Dockerfile.rhel
+++ b/oso-central-webapi-guard/Dockerfile.rhel
@@ -1,0 +1,16 @@
+FROM registry.devshift.net/osio-prod/base/httpd:latest
+
+RUN sed -i -e "s,Listen 80,Listen 8001," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
+EXPOSE 8001
+
+COPY oso_central_webapi_guard.conf /etc/httpd/conf.d/oso_central_webapi_guard.conf
+COPY pmwebd_guard.htpasswd /etc/httpd/conf/pmwebd_guard.htpasswd
+RUN chmod a+rwX /run/httpd
+
+VOLUME /var/log/pcp
+
+STOPSIGNAL SIGWINCH
+
+ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]

--- a/oso-pcp-prometheus/Dockerfile.rhel
+++ b/oso-pcp-prometheus/Dockerfile.rhel
@@ -1,0 +1,6 @@
+FROM registry.devshift.net/osio-prod/base/pcp:latest
+
+# Expose pmwebd's main port on the host interface
+EXPOSE 44323
+ENV MALLOC_ARENA_MAX 1
+ENTRYPOINT ["/usr/libexec/pcp/bin/pmwebd", "-v", "-v", "-h", "localhost", "-N"]

--- a/oso-webapi-guard/Dockerfile.rhel
+++ b/oso-webapi-guard/Dockerfile.rhel
@@ -1,0 +1,23 @@
+FROM registry.devshift.net/osio-prod/base/httpd:latest
+
+RUN sed -i -e "s,Listen 80,Listen 8001," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
+EXPOSE 8001
+
+COPY pmwebd_guard.conf /etc/httpd/conf.d/pmwebd_guard.conf
+
+# the htpasswd file may be periodically replaced during run
+RUN touch                  /etc/httpd/conf/pmwebd_guard.htpasswd
+RUN chmod a+rwX            /etc/httpd/conf /etc/httpd/conf/pmwebd_guard.htpasswd
+RUN chmod a+rwX            /run/httpd
+
+COPY webapi_guard_start.sh /webapi_guard_start.sh
+
+# where to fetch htpasswd updates from
+ENV OSIO_NAMESPACE ""
+ENV OSIO_ACL_SERVER ""
+
+STOPSIGNAL SIGWINCH
+
+ENTRYPOINT ["/bin/sh", "/webapi_guard_start.sh"]

--- a/pcp-bayesian-central-logger/Dockerfile.rhel
+++ b/pcp-bayesian-central-logger/Dockerfile.rhel
@@ -1,0 +1,20 @@
+FROM registry.devshift.net/osio-prod/base/osd-loggers:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+COPY pmmgr+pmcd.sh   /pmmgr+pmcd.sh
+
+ADD pmmgr-pod /etc/pcp/pmmgr-pod
+
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \  
+    /usr/bin/fix-permissions /var/log/pcp
+
+ENV MALLOC_ARENA_MAX 1
+ENV ZABBIX_SERVER    localhost
+
+ENV VALGRIND ""
+# ENV VALGRIND /usr/bin/valgrind
+
+VOLUME /var/log/pcp
+ENTRYPOINT [ "/bin/sh", "/pmmgr+pmcd.sh" ]

--- a/pcp-bayesian-webapi-guard/Dockerfile.rhel
+++ b/pcp-bayesian-webapi-guard/Dockerfile.rhel
@@ -1,0 +1,19 @@
+FROM registry.devshift.net/osio-prod/base/httpd:latest
+
+RUN sed -i -e "s,Listen 80,Listen 8000," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
+EXPOSE 8000
+
+COPY pmwebd_guard.conf /etc/httpd/conf.d/pmwebd_guard.conf
+COPY pmwebd_guard.htpasswd /etc/httpd/conf/pmwebd_guard.htpasswd
+RUN chmod a+rwX /run/httpd
+
+COPY index.html /var/www/html
+
+VOLUME /var/log/pcp
+
+STOPSIGNAL SIGWINCH
+
+# ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]

--- a/pcp-central-logger/Dockerfile.rhel
+++ b/pcp-central-logger/Dockerfile.rhel
@@ -1,0 +1,23 @@
+FROM registry.devshift.net/osio-prod/base/osd-loggers:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+COPY pmmgr+pmcd.sh   /pmmgr+pmcd.sh
+COPY pminfo-sleep.sh /pminfo-sleep.sh
+
+ADD pmmgr-node /etc/pcp/pmmgr-node
+ADD pmmgr-pod /etc/pcp/pmmgr-pod
+ADD pmmgr-db /etc/pcp/pmmgr-db
+
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \  
+    /usr/bin/fix-permissions /var/log/pcp
+
+ENV MALLOC_ARENA_MAX 1
+ENV ZABBIX_SERVER    localhost
+
+ENV VALGRIND ""
+# ENV VALGRIND /usr/bin/valgrind
+
+VOLUME /var/log/pcp
+ENTRYPOINT [ "/bin/sh", "/pmmgr+pmcd.sh" ]

--- a/pcp-central-webapi/Dockerfile.rhel
+++ b/pcp-central-webapi/Dockerfile.rhel
@@ -1,0 +1,12 @@
+FROM registry.devshift.net/osio-prod/base/pcp:latest
+
+# Expose pmwebd's main port on the host interface
+EXPOSE 44323
+
+VOLUME /var/log/pcp
+
+ENV MALLOC_ARENA_MAX 1
+
+# -M8?
+
+ENTRYPOINT ["/usr/libexec/pcp/bin/pmwebd", "-v", "-v", "-G", "-X", "-R", "/usr/share/pcp/webapps", "-A", "/var/log/pcp/pmmgr", "-i", "15", "-P", "-J", "-L", "-M8"]

--- a/pcp-node-collector/Dockerfile.rhel
+++ b/pcp-node-collector/Dockerfile.rhel
@@ -1,0 +1,15 @@
+FROM registry.devshift.net/osio-prod/base/pcp:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+COPY ./run-pmcd.sh /run-pmcd.sh
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /bin/mkdir -p /var/run/pcp && \
+    /usr/bin/fix-permissions /var/run/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \
+    /usr/bin/fix-permissions /var/log/pcp
+# Expose pmcd's main port on the host interface
+EXPOSE 44321
+
+ENV PCP_HOSTNAME node-deadbeef
+ENTRYPOINT ["/run-pmcd.sh"]

--- a/pcp-postgresql-monitor/Dockerfile.rhel
+++ b/pcp-postgresql-monitor/Dockerfile.rhel
@@ -1,0 +1,22 @@
+FROM registry.devshift.net/osio-prod/base/pcp:latest
+
+COPY fix-permissions /usr/bin/fix-permissions
+COPY pmcd.sh   /pmcd.sh
+
+RUN chmod +x /usr/bin/fix-permissions && \
+    /usr/bin/fix-permissions /etc/pcp && \
+    /usr/bin/fix-permissions /var/lib/pcp && \  
+    /usr/bin/fix-permissions /var/log/pcp
+
+ENV DB_HOSTNAME ""
+ENV DB_PORT "5432"
+ENV DB_DB ""
+ENV DB_USER ""
+ENV DB_PASSWORD ""
+ENV PCP_HOSTNAME "DB-unset"
+ENV PMCD_PORT "44321"
+
+EXPOSE 44321
+
+VOLUME /var/log/pcp
+ENTRYPOINT [ "/bin/sh", "/pmcd.sh" ]

--- a/pcp-webapi-guard/Dockerfile.rhel
+++ b/pcp-webapi-guard/Dockerfile.rhel
@@ -1,0 +1,19 @@
+FROM registry.devshift.net/osio-prod/base/httpd:latest
+
+RUN sed -i -e "s,Listen 80,Listen 8000," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
+RUN sed -i -e "s,logs/access_log,/dev/stdout," /etc/httpd/conf/httpd.conf
+EXPOSE 8000
+
+COPY pmwebd_guard.conf /etc/httpd/conf.d/pmwebd_guard.conf
+COPY pmwebd_guard.htpasswd /etc/httpd/conf/pmwebd_guard.htpasswd
+RUN chmod a+rwX /run/httpd
+
+COPY index.html /var/www/html
+
+VOLUME /var/log/pcp
+
+STOPSIGNAL SIGWINCH
+
+# ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

cc: @fche 