### PR TITLE
Enable RHEL images

### DIFF
--- a/bayesian-monitor.yml
+++ b/bayesian-monitor.yml
@@ -26,7 +26,7 @@ objects:
             persistentVolumeClaim:
               claimName: osd-monitor-pcplogs
         containers:
-        - image: 'registry.devshift.net/perf/pcp-bayesian-central-logger:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-bayesian-central-logger:${IMAGE_TAG}'
           name: pcp-bayesian-central-logger
           volumeMounts:
             - name: pcp-logs
@@ -37,7 +37,7 @@ objects:
               value: zabbix.devshift.net
             - name: VALGRIND
               value: ~
-        - image: 'registry.devshift.net/perf/pcp-central-webapi:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-central-webapi:${IMAGE_TAG}'
           name: pcp-central-webapi
           volumeMounts:
             - name: pcp-logs
@@ -52,7 +52,7 @@ objects:
             initiaDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 10
-        - image: 'registry.devshift.net/perf/pcp-bayesian-webapi-guard:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-bayesian-webapi-guard:${IMAGE_TAG}'
           name: pcp-webapi-guard
           volumeMounts:
             - name: pcp-logs

--- a/osd-monitor.yml
+++ b/osd-monitor.yml
@@ -26,7 +26,7 @@ objects:
             persistentVolumeClaim:
               claimName: osd-monitor-pcplogs
         containers:
-        - image: 'registry.devshift.net/perf/pcp-central-logger:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-central-logger:${IMAGE_TAG}'
           name: pcp-central-logger
           volumeMounts:
             - name: pcp-logs
@@ -43,7 +43,7 @@ objects:
             requests:
               cpu: 1m
               memory: 500Mi
-        - image: 'registry.devshift.net/perf/pcp-central-webapi:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-central-webapi:${IMAGE_TAG}'
           name: pcp-central-webapi
           volumeMounts:
             - name: pcp-logs
@@ -65,7 +65,7 @@ objects:
             requests:
               cpu: 1m
               memory: 500Mi
-        - image: 'registry.devshift.net/perf/pcp-webapi-guard:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-webapi-guard:${IMAGE_TAG}'
           name: pcp-webapi-guard
           volumeMounts:
             - name: pcp-logs
@@ -87,7 +87,7 @@ objects:
             requests:
               cpu: 1m
               memory: 50Mi
-        - image: 'registry.devshift.net/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
           name: pcp-postgresql-f8tenant
           env:
             - name: PCP_HOSTNAME
@@ -124,7 +124,7 @@ objects:
             requests:
               cpu: 1m
               memory: 50Mi
-        - image: 'registry.devshift.net/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
           name: pcp-postgresql-auth
           env:
             - name: PCP_HOSTNAME
@@ -158,7 +158,7 @@ objects:
             requests:
               cpu: 1m
               memory: 50Mi
-        - image: 'registry.devshift.net/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
           name: pcp-postgresql-core
           env:
             - name: PCP_HOSTNAME
@@ -192,7 +192,7 @@ objects:
             requests:
               cpu: 1m
               memory: 50Mi
-        - image: 'registry.devshift.net/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-postgresql-monitor:${IMAGE_TAG}'
           name: pcp-postgresql-jenkins-proxy
           env:
             - name: PCP_HOSTNAME
@@ -300,7 +300,7 @@ objects:
                 path: oso.tenant.salt
                 mode: 292
         containers:
-        - image: 'registry.devshift.net/perf/oso-central-logger:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/oso-central-logger:${IMAGE_TAG}'
           name: oso-central-logger
           volumeMounts:
             - name: pcp-logs
@@ -317,7 +317,7 @@ objects:
             requests:
               cpu: 1m
               memory: 500Mi
-        - image: 'registry.devshift.net/perf/pcp-central-webapi:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/pcp-central-webapi:${IMAGE_TAG}'
           name: pcp-central-webapi
           volumeMounts:
             - name: pcp-logs
@@ -339,7 +339,7 @@ objects:
             requests:
               cpu: 1m
               memory: 500Mi
-        - image: 'registry.devshift.net/perf/oso-central-webapi-guard:${IMAGE_TAG}'
+        - image: 'prod.registry.devshift.net/osio-prod/perf/oso-central-webapi-guard:${IMAGE_TAG}'
           name: oso-central-webapi-guard
           volumeMounts:
             - name: pcp-logs


### PR DESCRIPTION
Enable RHEL images

@fche I was able to find in that repo only these images used:
```
pcp-bayesian-central-logger
pcp-bayesian-webapi-guard
pcp-central-logger
pcp-central-webapi
pcp-webapi-guard
pcp-postgresql-monitor
oso-central-logger
oso-central-webapi-guard
```

but these are not used in that repo, can you point me please where these images are used to update the links for them or they just obsolete?
```
mm-zabbix-relay
oso-pcp-prometheus
oso-webapi-guard
pcp-node-collector
```


@fche another note that  I was unable to find where `bayesian-monitor.yml` is used but found this: https://github.com/openshiftio/saas-analytics/pull/183, so does this a right PR for `bayesian-monitor.yml` from that repo? If so it have to be updated after this PR will be merged
cc @syamgk @rawlingsj 