### PR TITLE
Move to Quay.io

### DIFF
--- a/bayesian-monitor.yml
+++ b/bayesian-monitor.yml
@@ -107,11 +107,11 @@ objects:
       insecureEdgeTerminationPolicy: Redirect
 parameters:
 - name: IMAGE_PCP_BAYESIAN_CENTRAL_LOGGER
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-bayesian-central-logger
+  value: quay.io/openshiftio/rhel-perf-pcp-bayesian-central-logger
 - name: IMAGE_PCP_CENTRAL_WEBAPI
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-central-webapi
+  value: quay.io/openshiftio/rhel-perf-pcp-central-webapi
 - name: IMAGE_PCP_BAYESIAN_WEBAPI_GUARD
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-bayesian-webapi-guard
+  value: quay.io/openshiftio/rhel-perf-pcp-bayesian-webapi-guard
 - name: IMAGE_TAG
   value: latest
 - apiVersion: v1

--- a/mm-zabbix-relay/Dockerfile.rhel
+++ b/mm-zabbix-relay/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo
@@ -10,7 +10,7 @@ ADD pmmgr-mm /etc/pcp/pmmgr-mm
 
 RUN chmod +x /usr/bin/fix-permissions && \
     /usr/bin/fix-permissions /etc/pcp && \
-    /usr/bin/fix-permissions /var/lib/pcp && \  
+    /usr/bin/fix-permissions /var/lib/pcp && \
     /usr/bin/fix-permissions /var/log/pcp
 
 ENV MALLOC_ARENA_MAX 1

--- a/osd-monitor.yml
+++ b/osd-monitor.yml
@@ -394,16 +394,16 @@ objects:
       insecureEdgeTerminationPolicy: Redirect
 parameters:
 - name: IMAGE_PCP_CENTRAL_LOGGER
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-central-logger
+  value: quay.io/openshiftio/rhel-perf-pcp-central-logger
 - name: IMAGE_PCP_CENTRAL_WEBAPI
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-central-webapi
+  value: quay.io/openshiftio/rhel-perf-pcp-central-webapi
 - name: IMAGE_PCP_WEBAPI_GUARD
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-webapi-guard
+  value: quay.io/openshiftio/rhel-perf-pcp-webapi-guard
 - name: IMAGE_PCP_POSTGRESQL
-  value: prod.registry.devshift.net/osio-prod/perf/pcp-postgresql-monitor
+  value: quay.io/openshiftio/rhel-perf-pcp-postgresql-monitor
 - name: IMAGE_OSO_CENTRAL_LOGGER
-  value: prod.registry.devshift.net/osio-prod/perf/oso-central-logger
+  value: quay.io/openshiftio/rhel-perf-oso-central-logger
 - name: IMAGE_OSO_CENTRAL_WEBAPI_GUARD
-  value: prod.registry.devshift.net/osio-prod/perf/oso-central-webapi-guard
+  value: quay.io/openshiftio/rhel-perf-oso-central-webapi-guard
 - name: IMAGE_TAG
   value: latest

--- a/oso-central-logger/Dockerfile.rhel
+++ b/oso-central-logger/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/osd-loggers:latest
+FROM quay.io/openshiftio/rhel-base-osd-loggers:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/oso-central-webapi-guard/Dockerfile.rhel
+++ b/oso-central-webapi-guard/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/httpd:latest
+FROM quay.io/openshiftio/rhel-base-httpd:latest
 
 RUN sed -i -e "s,Listen 80,Listen 8001," /etc/httpd/conf/httpd.conf
 RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf

--- a/oso-pcp-prometheus/Dockerfile.rhel
+++ b/oso-pcp-prometheus/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/oso-webapi-guard/Dockerfile.rhel
+++ b/oso-webapi-guard/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/httpd:latest
+FROM quay.io/openshiftio/rhel-base-httpd:latest
 
 RUN sed -i -e "s,Listen 80,Listen 8001," /etc/httpd/conf/httpd.conf
 RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf

--- a/pcp-bayesian-central-logger/Dockerfile.rhel
+++ b/pcp-bayesian-central-logger/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/osd-loggers:latest
+FROM quay.io/openshiftio/rhel-base-osd-loggers:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/pcp-bayesian-webapi-guard/Dockerfile.rhel
+++ b/pcp-bayesian-webapi-guard/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/httpd:latest
+FROM quay.io/openshiftio/rhel-base-httpd:latest
 
 RUN sed -i -e "s,Listen 80,Listen 8000," /etc/httpd/conf/httpd.conf
 RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf

--- a/pcp-central-logger/Dockerfile.rhel
+++ b/pcp-central-logger/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/osd-loggers:latest
+FROM quay.io/openshiftio/rhel-base-osd-loggers:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/pcp-central-webapi/Dockerfile.rhel
+++ b/pcp-central-webapi/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/pcp-node-collector/Dockerfile.rhel
+++ b/pcp-node-collector/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/pcp-postgresql-monitor/Dockerfile.rhel
+++ b/pcp-postgresql-monitor/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 
 # Install pcp - collection basics
 COPY pcp.repo /etc/yum.repos.d/pcp.repo

--- a/pcp-webapi-guard/Dockerfile.rhel
+++ b/pcp-webapi-guard/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/httpd:latest
+FROM quay.io/openshiftio/rhel-base-httpd:latest
 
 RUN sed -i -e "s,Listen 80,Listen 8000," /etc/httpd/conf/httpd.conf
 RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should
  not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo
to change the staging url from devshift to quay. The PR to the saas
repo should be merged before this one.

https://github.com/openshiftio/saas-openshiftio/pull/984