### PR TITLE
Add Quay imagepullsecrets to ServiceAccount

### DIFF
--- a/osd-monitor.yml
+++ b/osd-monitor.yml
@@ -269,6 +269,8 @@ objects:
       insecureEdgeTerminationPolicy: Redirect
 - apiVersion: v1
   kind: ServiceAccount
+  imagePullSecrets:
+  - name: quay.io
   metadata:
     name: osd-monitor
 parameters:


### PR DESCRIPTION
When this template processed and applied, the existing osd-monitor SA that has the quay.io imagepullsecrets linked would get overwritten, and unlink the image pull secret. This leads to a permission denied error pulling the image. To prevent this, this PR will add an entry with the imagepullsecret set in the SA definition.