### PR TITLE
create aliases for tenant counters

### DIFF
--- a/pcp-central-webapi/Dockerfile.rhel
+++ b/pcp-central-webapi/Dockerfile.rhel
@@ -7,6 +7,7 @@ RUN yum update -y pcp-webapi "pcp-webapp-*" && yum clean all
 COPY index.html /usr/share/pcp/webapps/index.html
 COPY che-gaugify-counters.conf /var/lib/pcp/config/derived
 COPY auth-gaugify-counters.conf /var/lib/pcp/config/derived
+COPY tenant-gaugify-counters.conf /var/lib/pcp/config/derived
 
 # Expose pmwebd's main port on the host interface
 EXPOSE 44323

--- a/pcp-central-webapi/tenant-gaugify-counters.conf
+++ b/pcp-central-webapi/tenant-gaugify-counters.conf
@@ -1,0 +1,6 @@
+# create instant aliases of counters, similar to  https://github.com/redhat-developer/rh-che/issues/1228
+
+prometheus.wit.provisioned_tenants = instant(prometheus.wit.provisioned_tenants_total)
+prometheus.wit.cleaned_tenants = instant(prometheus.wit.cleaned_tenants_total)
+prometheus.wit.updated_tenants = instant(prometheus.wit.updated_tenants_total)
+prometheus.wit.deleted_tenants = instant(prometheus.wit.deleted_tenants_total)


### PR DESCRIPTION
similar aliases as were introduced in https://github.com/redhat-developer/osd-monitor-poc/pull/47 but this time for tenant service metrics: https://github.com/fabric8-services/fabric8-tenant/blob/master/metric/metric.go